### PR TITLE
Fix CI and Documentation

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Run lint/format scripts
         uses: area44/workflows/lint-format@v4.1.1

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,10 +12,10 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Run build
         uses: area44/workflows/vite@v4.1.1

--- a/package.json
+++ b/package.json
@@ -34,5 +34,11 @@
     "oxlint": "^1.59.0",
     "typescript": "^5.7.3",
     "unified": "^11.0.5"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/mdast": "^4.0.4",
     "oxfmt": "^0.44.0",
     "oxlint": "^1.59.0",
-    "typescript": "^6.0.2",
+    "typescript": "^5.7.3",
     "unified": "^11.0.5"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,16 +10,16 @@ importers:
     dependencies:
       '@astrojs/starlight':
         specifier: ^0.38.3
-        version: 0.38.3(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3))
+        version: 0.38.3(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3))
       astro:
         specifier: ^6.1.5
-        version: 6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3)
+        version: 6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3)
       astro-mermaid:
         specifier: ^2.0.1
-        version: 2.0.1(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3))(mermaid@11.14.0)
+        version: 2.0.1(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3))(mermaid@11.14.0)
       astro-og-canvas:
         specifier: ^0.11.0
-        version: 0.11.0(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3))
+        version: 0.11.0(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3))
       canvaskit-wasm:
         specifier: ^0.41.1
         version: 0.41.1
@@ -52,7 +52,7 @@ importers:
         version: 0.34.5
       starlight-links-validator:
         specifier: ^0.23.0
-        version: 0.23.0(@astrojs/starlight@0.38.3(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3)))(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3))
+        version: 0.23.0(@astrojs/starlight@0.38.3(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3)))(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3))
     devDependencies:
       '@types/hast':
         specifier: ^3.0.4
@@ -67,8 +67,8 @@ importers:
         specifier: ^1.59.0
         version: 1.59.0
       typescript:
-        specifier: ^6.0.2
-        version: 6.0.2
+        specifier: ^5.7.3
+        version: 5.9.3
       unified:
         specifier: ^11.0.5
         version: 11.0.5
@@ -2400,8 +2400,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  typescript@6.0.2:
-    resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2701,12 +2701,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.0(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3))':
+  '@astrojs/mdx@5.0.0(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3))':
     dependencies:
       '@astrojs/markdown-remark': 7.0.0
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3)
+      astro: 6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3)
       es-module-lexer: 2.0.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -2734,17 +2734,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.3.6
 
-  '@astrojs/starlight@0.38.3(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3))':
+  '@astrojs/starlight@0.38.3(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.0
-      '@astrojs/mdx': 5.0.0(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3))
+      '@astrojs/mdx': 5.0.0(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3))
       '@astrojs/sitemap': 3.7.1
       '@pagefind/default-ui': 1.3.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3)
-      astro-expressive-code: 0.41.7(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3))
+      astro: 6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3)
+      astro-expressive-code: 0.41.7(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -3557,27 +3557,27 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.7(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3)):
+  astro-expressive-code@0.41.7(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3)):
     dependencies:
-      astro: 6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3)
+      astro: 6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3)
       rehype-expressive-code: 0.41.7
 
-  astro-mermaid@2.0.1(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3))(mermaid@11.14.0):
+  astro-mermaid@2.0.1(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3))(mermaid@11.14.0):
     dependencies:
-      astro: 6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3)
+      astro: 6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3)
       import-meta-resolve: 4.2.0
       mdast-util-to-string: 4.0.0
       mermaid: 11.14.0
       unist-util-visit: 5.1.0
 
-  astro-og-canvas@0.11.0(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3)):
+  astro-og-canvas@0.11.0(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3)):
     dependencies:
-      astro: 6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3)
+      astro: 6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3)
       canvaskit-wasm: 0.41.1
       deterministic-object-hash: 2.0.2
       entities: 8.0.0
 
-  astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3):
+  astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       '@astrojs/compiler': 3.0.1
       '@astrojs/internal-helpers': 0.8.0
@@ -3622,7 +3622,7 @@ snapshots:
       tinyclip: 0.1.12
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
-      tsconfck: 3.1.6(typescript@6.0.2)
+      tsconfck: 3.1.6(typescript@5.9.3)
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
@@ -5476,11 +5476,11 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  starlight-links-validator@0.23.0(@astrojs/starlight@0.38.3(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3)))(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3)):
+  starlight-links-validator@0.23.0(@astrojs/starlight@0.38.3(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3)))(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3)):
     dependencies:
-      '@astrojs/starlight': 0.38.3(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3))
+      '@astrojs/starlight': 0.38.3(astro@6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3))
       '@types/picomatch': 4.0.2
-      astro: 6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@6.0.2)(yaml@2.8.3)
+      astro: 6.1.5(@types/node@24.10.1)(jiti@2.4.2)(rollup@4.53.3)(typescript@5.9.3)(yaml@2.8.3)
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       is-absolute-url: 5.0.0
@@ -5551,14 +5551,14 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  tsconfck@3.1.6(typescript@6.0.2):
+  tsconfck@3.1.6(typescript@5.9.3):
     optionalDependencies:
-      typescript: 6.0.2
+      typescript: 5.9.3
 
   tslib@2.8.1:
     optional: true
 
-  typescript@6.0.2: {}
+  typescript@5.9.3: {}
 
   ufo@1.6.3: {}
 

--- a/src/content/docs/starlight/og-images.mdx
+++ b/src/content/docs/starlight/og-images.mdx
@@ -27,7 +27,7 @@ This guide will show one possible way to add OG images to Starlight.
 
     const pages = Object.fromEntries(entries.map(({ data, id }) => [id, { data }]));
 
-    export const { getStaticPaths, GET } = OGImageRoute({
+    export const { getStaticPaths, GET } = await OGImageRoute({
       pages,
       param: "route",
       getImageOptions: (_path, page: (typeof pages)[number]) => {


### PR DESCRIPTION
This PR fixes CI failures and a documentation error.
1. The GitHub Actions runner `ubuntu-slim` was invalid; it has been changed to `ubuntu-latest`.
2. The `actions/checkout@v6` version was invalid; it has been downgraded to `v4`.
3. Added a missing `await` to a code example in the OG images guide to match the actual implementation.
4. Adjusted the TypeScript version to a stable release (^5.7.3).

---
*PR created automatically by Jules for task [2069009317688612069](https://jules.google.com/task/2069009317688612069) started by @imnhatnguyen*