### PR TITLE
Fix OG images not found by aligning IDs and supporting BASE_URL

### DIFF
--- a/src/content/docs/starlight/og-images.mdx
+++ b/src/content/docs/starlight/og-images.mdx
@@ -27,10 +27,14 @@ This guide will show how to add OG images to Starlight using `takumi-js`, a fast
 
     export async function getStaticPaths() {
       const entries = await getCollection("docs");
-      return entries.map((entry) => ({
-        params: { route: `${entry.id || "index"}.png` },
-        props: { title: entry.data.title, description: entry.data.description },
-      }));
+      return entries.map((entry) => {
+        // Strip file extension from entry.id to match Starlight's route ID
+        const id = entry.id.replace(/\.[^/.]+$/, "");
+        return {
+          params: { route: `${id || "index"}.png` },
+          props: { title: entry.data.title, description: entry.data.description },
+        };
+      });
     }
 
     export const GET: APIRoute = async ({ props }) => {
@@ -81,26 +85,27 @@ This guide will show how to add OG images to Starlight using `takumi-js`, a fast
 
     ```ts
     // src/routeData.ts
-    ---
-    import { defineRouteMiddleware } from "@astrojs/starlight/route-data"
+    import { defineRouteMiddleware } from "@astrojs/starlight/route-data";
 
     export const onRequest = defineRouteMiddleware((context) => {
-      const ogImageUrl = new URL(
-        `/og/${context.locals.starlightRoute.id || "index"}.png`,
-        context.site,
-      )
+      const { id } = context.locals.starlightRoute;
 
-      const { head } = context.locals.starlightRoute
+      const ogImageUrl = new URL(
+        `${import.meta.env.BASE_URL.replace(/\/$/, "")}/og/${id || "index"}.png`,
+        context.site ?? context.url.origin,
+      );
+
+      const { head } = context.locals.starlightRoute;
 
       head.push({
         tag: "meta",
         attrs: { property: "og:image", content: ogImageUrl.href },
-      })
+      });
       head.push({
         tag: "meta",
         attrs: { name: "twitter:image", content: ogImageUrl.href },
-      })
-    })
+      });
+    });
     ```
 
 4.  **Configure Starlight in the `astro.config.mjs` file**

--- a/src/pages/og/[...route].ts
+++ b/src/pages/og/[...route].ts
@@ -5,10 +5,14 @@ import { ImageResponse } from "takumi-js/response";
 
 export async function getStaticPaths() {
   const entries = await getCollection("docs");
-  return entries.map((entry) => ({
-    params: { route: `${entry.id || "index"}.png` },
-    props: { title: entry.data.title, description: entry.data.description },
-  }));
+  return entries.map((entry) => {
+    // Strip file extension from entry.id to match Starlight's route ID
+    const id = entry.id.replace(/\.[^/.]+$/, "");
+    return {
+      params: { route: `${id || "index"}.png` },
+      props: { title: entry.data.title, description: entry.data.description },
+    };
+  });
 }
 
 export const GET: APIRoute = async ({ props }) => {

--- a/src/routeData.ts
+++ b/src/routeData.ts
@@ -1,9 +1,12 @@
 import { defineRouteMiddleware } from "@astrojs/starlight/route-data";
 
 export const onRequest = defineRouteMiddleware((context) => {
+  const { id } = context.locals.starlightRoute;
+
+  // Ensure the URL is correctly constructed using the site's base URL
   const ogImageUrl = new URL(
-    `/og/${context.locals.starlightRoute.id || "index"}.png`,
-    context.site,
+    `${import.meta.env.BASE_URL.replace(/\/$/, "")}/og/${id || "index"}.png`,
+    context.site ?? context.url.origin,
   );
 
   const { head } = context.locals.starlightRoute;


### PR DESCRIPTION
The OG images were not being found because of two main issues:
1. A mismatch between the IDs generated by `getCollection("docs")` (which included file extensions) and the IDs used by Starlight's route middleware (which do not). This resulted in the images being generated at paths like `/og/starlight/og-images.mdx.png` while the pages looked for `/og/starlight/og-images.png`.
2. The OG image URL construction did not account for the project's `BASE_URL`, which would cause issues if the site was hosted on a subpath.

I fixed these issues by:
- Stripping the extension from the entry ID in the OG image route generator.
- Incorporating `import.meta.env.BASE_URL` into the URL construction in the route middleware.

Verified the fix by running a full production build and checking the output files, as well as testing with a local dev server and Playwright.

---
*PR created automatically by Jules for task [1281296707257894108](https://jules.google.com/task/1281296707257894108) started by @torn4dom4n*