### PR TITLE
Fix CI failure after Starlight v0.39 update

### DIFF
--- a/config/sidebar.ts
+++ b/config/sidebar.ts
@@ -19,12 +19,12 @@ export function group(key: NavKey, group: any): any {
 
 export const astroSidebar = [
   group("astro.recipes", {
-    autogenerate: { directory: "astro" },
+    items: [{ autogenerate: { directory: "astro" } }],
   }),
 ] satisfies StarlightUserConfig["sidebar"];
 
 export const starlightSidebar = [
   group("starlight.recipes", {
-    autogenerate: { directory: "starlight" },
+    items: [{ autogenerate: { directory: "starlight" } }],
   }),
 ] satisfies StarlightUserConfig["sidebar"];

--- a/src/content/docs/starlight/split-sidebar.mdx
+++ b/src/content/docs/starlight/split-sidebar.mdx
@@ -40,13 +40,13 @@ By default, Starlight provides a vertical sidebar. For larger documentation site
 
     export const astroSidebar = [
       group("astro.recipes", {
-        autogenerate: { directory: "astro" },
+        items: [{ autogenerate: { directory: "astro" } }],
       }),
     ] satisfies StarlightUserConfig["sidebar"];
 
     export const starlightSidebar = [
       group("starlight.recipes", {
-        autogenerate: { directory: "starlight" },
+        items: [{ autogenerate: { directory: "starlight" } }],
       }),
     ] satisfies StarlightUserConfig["sidebar"];
     ```


### PR DESCRIPTION
This PR fixes the CI failure caused by the Starlight v0.39.0 update. The breaking change requires all `autogenerate` sidebar configurations to be nested within an `items` array.

Changes:
- Updated `config/sidebar.ts` to wrap `autogenerate` in `items`.
- Updated `src/content/docs/starlight/split-sidebar.mdx` to reflect the new configuration requirement in documentation examples.
- Verified with `pnpm build` and `pnpm check`.

---
*PR created automatically by Jules for task [13169330562889775189](https://jules.google.com/task/13169330562889775189) started by @torn4dom4n*